### PR TITLE
ignore empty session files

### DIFF
--- a/lib/connect-fs.js
+++ b/lib/connect-fs.js
@@ -14,10 +14,10 @@ var path = require('path');
 var events = require('events');
 
 /**
- * One day in seconds.
+ * One day in milliseconds.
  */
 
-var oneDay = 86400;
+var oneDay = 86400 * 1000;
 
 /**
  * Return the `FSStore` extending a `connect` session Store.
@@ -165,7 +165,7 @@ module.exports = function(session){
     try {
       var maxAge = sess.cookie.maxAge;
       var now = new Date().getTime();
-      var expired = maxAge ? now + maxAge : now + oneDay * 1000;
+      var expired = maxAge ? now + maxAge : now + oneDay;
       sess.expired = expired;
       sess = JSON.stringify(sess);
 

--- a/lib/connect-fs.js
+++ b/lib/connect-fs.js
@@ -133,9 +133,8 @@ module.exports = function(session){
           //try {
             if (!data) {
               // no session file
-              if (err) return fn();
               // the file is somehow empty. not much we can do, just continue.
-              else return fn();
+              return fn();
             }
             data = JSON.parse(data);
             if (data.expired < now) {

--- a/lib/connect-fs.js
+++ b/lib/connect-fs.js
@@ -165,7 +165,7 @@ module.exports = function(session){
     try {
       var maxAge = sess.cookie.maxAge;
       var now = new Date().getTime();
-      var expired = maxAge ? now + maxAge : now + oneDay;
+      var expired = maxAge ? now + maxAge : now + oneDay * 1000;
       sess.expired = expired;
       sess = JSON.stringify(sess);
 

--- a/lib/connect-fs.js
+++ b/lib/connect-fs.js
@@ -134,8 +134,8 @@ module.exports = function(session){
             if (!data) {
               // no session file
               if (err) return fn();
-              // something wrong
-              else return fn('something wrong');
+              // the file is somehow empty. not much we can do, just continue.
+              else return fn();
             }
             data = JSON.parse(data);
             if (data.expired < now) {


### PR DESCRIPTION
!data is true means that the file is just somehow empty. I think there is not much the user can do here. Maybe it's better just to ignore this and let a new session to be started. Or it will just hang all the requests. We even ignored it when err is not empty at line #136, right? It means we really don't care what happens.
